### PR TITLE
Cumulative Quantum Leap chart fixes

### DIFF
--- a/charts/quantumleap/README.MD
+++ b/charts/quantumleap/README.MD
@@ -52,12 +52,51 @@ This chart will do the following:
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release`:
+This chart deploys Quantum Leap to a Kubernetes cluster. The standalone
+deployment creates an HA, scalable replica set of Quantum Leap pods.
+Additionally, this chart can also be used to deploy Quantum Leap in
+work queue mode---only available for Quantum Leap versions `>= 0.8.2`.
+
+To be able to deploy Quantum Leap to your Kubernetes cluster through
+this chart, you first have to add the chart repository to your Helm
+installation as shown below.
 
 ```console
 $ helm repo add oc https://orchestracities.github.io/charts/
 $ helm dependency update
+```
+
+Then to perform a standalone deployment, install this chart with a
+release name of your choice, e.g. `my-release` as in the example
+below. (Note you can also override default chart settings through
+a "values" file as explained in the next section.)
+
+```console
 $ helm install --name my-release oc/quantumleap
+```
+
+To deploy Quantum Leap in work queue mode, you'll have to install
+this chart twice. One installation is for the Quantum Leap frontend
+whereas the other for the work queue backend. To install the frontend,
+you have to prepare a "values" file (see next section for the details)
+with `cache.wq.offloadWork` set to `true`. Then you need to specify
+a unique release name to identify the frontend installation as in
+the example below.
+
+```console
+$ helm install quantumleap --name fe -f fe.values.yaml
+```
+
+After installing the frontend, you need to install the work queue
+backend. Similarly to the frontend, you have to prepare a "values"
+file to configure the backend deployment. This is done by setting
+`cache.wq.workers` to a positive integer, the number of work queue
+processes to spawn in a single pod. Then install again using this
+"values" file and taking care of specifying a unique release name
+to identify the backend installation as in the example below.
+
+```console
+$ helm install quantumleap --name wq -f wq.values.yaml
 ```
 
 ## Connecting to QuantumLeap

--- a/charts/quantumleap/templates/deployment.yaml
+++ b/charts/quantumleap/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
     {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
     {{- end }}
-    {{- if .Values.init }}
+    {{- if .Values.init.enabled }}
       initContainers:
         - name: init-postgresql
           image: "{{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}"
@@ -65,6 +65,13 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if gt .Values.cache.wq.workers 0.0 }}
+          command:
+            - supervisord
+            - -n
+            - -c
+            - ./wq/supervisord.conf
+          {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           env:
@@ -75,7 +82,7 @@ spec:
           - name: CRATE_BACKOFF_FACTOR
             value: {{ .Values.database.crate.backoffFactor | quote }}
           - name: CRATE_WAIT_ACTIVE_SHARDS
-            value: {{ .Values.database.crate.waitActiveShards }}
+            value: {{ .Values.database.crate.waitActiveShards | quote }}
           - name: DEFAULT_LIMIT
             value: {{ .Values.runtime.defaultLimit | quote }}
           - name: KEEP_RAW_ENTITY
@@ -120,15 +127,15 @@ spec:
           - name: REDIS_PORT
             value: {{ .Values.redis.port | quote }}
           - name: CACHE_GEOCODING
-            value: {{ .Values.cache.geocoding }}
+            value: {{ .Values.cache.geocoding | quote }}
           - name: CACHE_QUERIES
-            value: {{ .Values.cache.queries }}
+            value: {{ .Values.cache.queries | quote }}
           - name: DEFAULT_CACHE_TTL
             value: {{ .Values.cache.defaultTtl | quote }}
           - name: WQ_OFFLOAD_WORK
-            value: {{ .Values.cache.wq.offloadWork }}
+            value: {{ .Values.cache.wq.offloadWork | quote }}
           - name: WQ_RECOVER_FROM_ENQUEUEING_FAILURE
-            value: {{ .Values.cache.wq.recoverFromEnqueueingFailure }}
+            value: {{ .Values.cache.wq.recoverFromEnqueueingFailure | quote }}
           - name: WQ_MAX_RETRIES
             value: {{ .Values.cache.wq.maxRetries | quote }}
           - name: WQ_FAILURE_TTL
@@ -140,7 +147,7 @@ spec:
             value: {{ .Values.cache.wq.workers | quote }}
           {{- end }}
           - name: USE_FLASK
-            value: {{ .Values.runtime.useFlask }}
+            value: {{ .Values.runtime.useFlask | quote }}
           - name: WORKERS
             value: {{ .Values.runtime.workers | quote }}
           - name: THREADS
@@ -189,7 +196,7 @@ spec:
           configMap:
             name: {{ template "quantumleap.fullname" . }}
       {{- end }}
-      {{- if .Values.init }}
+      {{- if .Values.init.enabled }}
         - name: init
           emptyDir: {}
       {{- end }}

--- a/charts/quantumleap/values.yaml
+++ b/charts/quantumleap/values.yaml
@@ -102,6 +102,7 @@ config:
   # default-backend: "Crate"
 
 init:
+  enabled: false
   password: password
   # Secret must be set manually in the namespace and overrides the above set password if provided. Key has to be "password".
   # passwordSecret: quantumleap-pg-init


### PR DESCRIPTION
This PR fixes some issues with the original PR @modularTaco submitted back in the day

- https://github.com/orchestracities/charts/pull/90/

Since quite some time has passed since that initial PR, some extensions to @modularTaco's original submission were needed:

- Switch to make the chart usable for work queue deployments too. Basically all we needed was a K8s command switch which changes the command if the chart gets used for a work queue deployment.
- Quoting of some env var values---this avoids errors with old k8s and QL versions
- On demand Postgres init container. The base values files will always put in a Postgres init container. A chart user may want to override this, but removing the `init` stanza from their own value file would have no effect. This PR adds an `enable` flag to the `init` stanza so chart users can decide whether or not they want to have the init container.
- Docs to explain how to use this chart to do a standalone or work queue deployment.
